### PR TITLE
Fix echo360 to include .net.au

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -14,7 +14,9 @@
                 "https://echo360.org/section/*",
                 "http://echo360.org/section/*",
                 "https://echo360.org.au/section/*",
-                "http://echo360.org.au/section/*"
+                "http://echo360.org.au/section/*",
+                "http://echo360.net.au/section/*",
+                "https://echo360.net.au/section/*"
             ],
             "js": [
                 "js/custom-file-names.js"
@@ -27,7 +29,9 @@
                 "https://echo360.org/lesson/*",
                 "http://echo360.org/lesson/*",
                 "https://echo360.org.au/lesson/*",
-                "http://echo360.org.au/lesson/*"
+                "http://echo360.org.au/lesson/*",
+                "http://echo360.net.au/lesson/*",
+                "https://echo360.net.au/lesson/*"
             ],
             "js": [
                 "js/more-speed-options.js"
@@ -40,7 +44,9 @@
                 "https://echo360.org/section/*",
                 "http://echo360.org/section/*",
                 "https://echo360.org.au/section/*",
-                "http://echo360.org.au/section/*"
+                "http://echo360.org.au/section/*",
+                "http://echo360.net.au/section/*",
+                "https://echo360.net.au/section/*"
             ],
             "js": [
                 "js/day-with-dates.js"
@@ -53,7 +59,9 @@
                 "https://echo360.org/section/*",
                 "http://echo360.org/section/*",
                 "https://echo360.org.au/section/*",
-                "http://echo360.org.au/section/*"
+                "http://echo360.org.au/section/*",
+                "http://echo360.net.au/section/*",
+                "https://echo360.net.au/section/*"
             ],
             "css": [
                 "css/reposition-popup.css"
@@ -65,7 +73,9 @@
                 "https://echo360.org/section/*",
                 "http://echo360.org/section/*",
                 "https://echo360.org.au/section/*",
-                "http://echo360.org.au/section/*"
+                "http://echo360.org.au/section/*",
+                "http://echo360.net.au/section/*",
+                "https://echo360.net.au/section/*"
             ],
             "js": [
                 "js/hide-future-lectures.js"


### PR DESCRIPTION
@EnBr55 fixed manifest.json to include the updated url format of "echo.net.au/*", required as the new domain of echo360